### PR TITLE
Fix Windows PATH lookup

### DIFF
--- a/which.js
+++ b/which.js
@@ -47,8 +47,9 @@ function which (cmd, opt, cb) {
   if (isWindows && !pathEnv) {
     var k = Object.keys(process.env)
     for (var p = 0; p < k.length; p++) {
-      if (p.toLowerCase() === 'path') {
-        pathEnv = process.env[p]
+      var key = k[p]
+      if (key.toLowerCase() === 'path') {
+        pathEnv = process.env[key]
         break
       }
     }


### PR DESCRIPTION
Npm was broken on Windows machine for recent version of nodejs (v0.12.7).
Cause: Array index was treated as environment var name.